### PR TITLE
Remove image reference inside Hub icon

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -28,10 +28,6 @@
 		<rect x="93.9" y="113.6" class="st3" width="25.7" height="5.5"/>
 		<rect x="93.9" y="126.8" class="st3" width="58.9" height="5.5"/>
 		<rect x="93.9" y="139.4" class="st3" width="42.3" height="5.5"/>
-		<g class="st4">
-			<image style="overflow:visible;" width="181" height="84" xlink:href="BE09515C.png"  transform="matrix(1 0 0 1 156 111)">
-			</image>
-		</g>
 		<rect x="187.9" y="33.8" class="st3" width="122" height="81.5"/>
 		<rect x="187.8" y="111.5" class="st3" width="122.1" height="40.4"/>
 		<g>


### PR DESCRIPTION
The reference to the png image inside the Hub icon cannot be resolved (nothing there) and on some servers seems to cause security issues.