### PR TITLE
Fix decrementing tasks left for non-task exercises

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -708,7 +708,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
           section.taskDone = sectionInstance.getAnswerGiven ? sectionInstance.getAnswerGiven() : true;
                     
           this.sideBar.setSectionMarker(chapterId, index);
-          if (section.taskDone) {
+          if (section.isTask && section.taskDone) {
             this.chapters[chapterId].tasksLeft -= 1;
           }
           this.updateChapterProgress(chapterId);


### PR DESCRIPTION
If the `Column.isTask` function does not report a content type to be a task (usually scorable), but the content type sends out xAPI statements, then Interactive Book may decrease the number of tasks left by 1 and this leads to a wrong count of interactions on the summary screen.

This can, for instance, happen for Agamotto that is not considered to be a task (not scored), but sends out xAPI `completed` once all images have been shown.

When merged in, the number of tasks left will only be reduced by 1 if the instance at hand is considered to be a task.