### PR TITLE
Add styling options to cover description

### DIFF
--- a/language/de.json
+++ b/language/de.json
@@ -8,8 +8,8 @@
       "label": "Titelseite",
       "fields": [
         {
-          "label": "Untertitel",
-          "description": "Dieser Text wird in kleinerer Schrift unter dem eigentlichen Titel angezeigt."
+          "label": "Beschreibung",
+          "description": "Dieser Text wird zur Beschreibung des Buchs unter dem eigentlichen Titel angezeigt."
         },
         {
           "label": "Titelbild",

--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
   "title": "Interactive Book",
   "description": "An interactive book which displays content in pages and sections",
   "majorVersion": 1,
-  "minorVersion": 5,
+  "minorVersion": 6,
   "patchVersion": 0,
   "runnable": 1,
   "fullscreen": 1,

--- a/semantics.json
+++ b/semantics.json
@@ -30,6 +30,7 @@
         "importance": "medium",
         "optional": true,
         "description": "This text will be the description of your book.",
+        "default": "<p style=\"text-align: center;\"></p>",
         "enterMode": "p",
         "tags": [
           "sub",

--- a/semantics.json
+++ b/semantics.json
@@ -38,8 +38,27 @@
           "strong",
           "em",
           "p",
-          "code"
-        ]
+          "code",
+          "u",
+          "del",
+          "a",
+          "ul",
+          "ol",
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+          "pre",
+          "hr",
+          "table"
+        ],
+        "font": {
+          "size": true,
+          "color": true,
+          "background": true
+        }
       },
       {
         "name": "coverImage",

--- a/src/styles/_cover.scss
+++ b/src/styles/_cover.scss
@@ -60,8 +60,7 @@
   font-size: 1.25em;
   font-weight: 400;
   margin-bottom: .5em;
-  max-width: 80%;
-  text-align: center;
+  width: 80%;
   text-decoration: none solid $medium-grey;
 }
 

--- a/upgrades.js
+++ b/upgrades.js
@@ -1,0 +1,26 @@
+var H5PUpgrades = H5PUpgrades || {};
+
+H5PUpgrades['H5P.InteractiveBook'] = (function () {
+  return {
+    1: {
+      /**
+       * Upgrade cover description to not imply "centered"
+       * @param {object} parameters Parameters of content.
+       * @param {function} finished Callback.
+       * @param {object} extras Metadata.
+       */
+      6: function (parameters, finished, extras) {
+        if (parameters && parameters.bookCover && parameters.bookCover.coverDescription) {
+          if (parameters.bookCover.coverDescription.substr(0, 2) !== '<p') {
+            parameters.bookCover.coverDescription = '<p style="text-align: center;">' + parameters.bookCover.coverDescription + '</p>'; // was plain text
+          }
+          else {
+            parameters.bookCover.coverDescription = parameters.bookCover.coverDescription.replace(/<p[^>]*>/g, '<p style="text-align: center;">');
+          }
+        }
+
+        finished(null, parameters, extras);
+      }
+    }
+  };
+})();


### PR DESCRIPTION
Currently, Interactive Book has only limited styling options for the book's description on the start screen.

When this pull request is merged in, the author will be able to choose from more styling options for the description (including text alignment instead of ignoring that setting in the editor and enforcing centered alignment)