### PR TITLE
WIP: add options hideScoreBeforeSubmit, showSolutionsAfterSubmit

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -180,6 +180,20 @@
         "default": true
       },
       {
+        "name": "hideScoreBeforeSubmit",
+        "type": "boolean",
+        "label": "Hide score before submit",
+        "description": "When enabled the user can see there score in summary page,after they have submited there answers",
+        "default": false
+      },
+      {
+        "name": "showSolutionsAfterSubmit",
+        "type": "boolean",
+        "label": "Show Solutions After Submit",
+        "description": "When enabled all Solutions are shown after submiting the answers",
+        "default": false
+      },
+      {
         "name": "enableRetry",
         "type": "boolean",
         "label": "Enable \"Restart\" button",

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -70,6 +70,8 @@ export default class InteractiveBook extends H5P.EventDispatcher {
      */
     this.params.behaviour.enableSolutionsButton = false;
     this.params.behaviour.enableRetry = this.params.behaviour.enableRetry ?? true;
+    this.params.behaviour.hideScoreBeforeSubmit = this.params.behaviour.hideScoreBeforeSubmit ?? false;
+    this.params.behaviour.showSolutionsAfterSubmit = this.params.behaviour.showSolutionsAfterSubmit ?? false;
 
     /**
      * Check if result has been submitted or input has been given.


### PR DESCRIPTION
My goal is that you only can  view you score after you have submitted your answers.
see also #133

I have made a options `hideScoreBeforeSubmit` that enables this.

Also add option `showSolutionsAfterSubmit` that will make interactive book will show Solutions of all question after submit answers. 

# TODO 

- [ ] clean up
- [ ] I don't like how score in written now after submit.  now is:
       - chapter is redrawn.
       - then `.h5p-interactive-book-summary-buttons`  is found and styled/focused 
- [ ] save and restore that you have submitted you answers 