### PR TITLE
JI-6555 H5P Taking focus canva - quick fix accessibility

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -484,7 +484,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         const container = this.pageContent.container;
         container.scrollBy(0, -container.scrollHeight);
       }
-      else if (H5PIntegration.context !== 'lti') {
+      else if (H5PIntegration.context !== 'lti') { // Will be changed in JI-6581 to not use H5PIntegration 
         this.statusBarHeader.wrapper.scrollIntoView(true);
       }
     });
@@ -1013,7 +1013,10 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         this.setActivityStarted();
 
         // Focus header progress bar when cover is removed
-        this.statusBarHeader.progressBar.progress.focus({ preventScroll: true });
+        // Will be changed in JI-6581 to not use H5PIntegration 
+        if (H5PIntegration.context !== 'lti') {
+          this.statusBarHeader.progressBar.progress.focus();
+        }
       });
     }
     else {


### PR DESCRIPTION
- **Fix invalid library.json**
- **Fix content width not taking containers full width**
- **Fix prepending DOM node (prepend not supported by IE11)**
- **Fix alignement in navbar title (IE11)**
- **Fix findIndex (not supported by IE11)**
- **Change encoding**
- **Fix use of URLUtils.hash, not supported by IE11**
- **Fix mixed spaces/tabs**
- **Fix using classlist.add/remove for IE11**
- **Fix navbar element position (IE11)**
- **Fix premature resizing**
- **Remove 'q' file**
- **Update package lock**
- **JI-978 Fix hiding of navigation bar in FireFox**
- **Add support for resizing event + bubbling to children**
- **JI-986 Fix link title**
- **JI-987 Add support for completed events**
- **JI-980 Fix active chapter expanded on load**
- **Remove scollbars when animating**
- **Fix support for more than 10 chapters**
- **Fix Start button not working in IE11**
- **Fix proper capitalization for dependency**
- **HFP-2452 Implement Question Type Contract**
- **HFP-2452 Fix score summation for Contract**
- **HFP-2454 Fix getAnswersGiven to require all answers**
- **JI-991 Fix updating progress for text-only columns**
- **HFP-2459 Fix left navigation menu getting cut off in full screen**
- **HFP-2461 Fix footer always being displayed on first view**
- **HFP-2463 Fix only navigating active book when hash changes**
- **HFP-2454 Stop setting properties on H5P instances**
- **HFP-2454 Stop setting properties on Column child instances**
- **HFP-2462 Update chapter completion/xAPI handling**
- **HFP-2462 Fix detection of final chapter**
- **HFP-2453 Generalize URL fragment extraction function**
- **HFP-2543 Generalize fragment string creation**
- **HFP-2453 Move URL fragment functions to new file**
- **HFP-2451 Improve JSDoc and related variable naming**
- **HFP-2451 Change quick wins**
- **HFP-2460 Fix accessibility issues**
- **HFP-2460 Fix extending params**
- **HFP-2460 Remove unused extend function**
- **HFP-2451 Rename variables**
- **HFP-2471 Fix overflowing left nav menu**
- **HFP-2471 Fix hiding cover when accessing book through a chapter link**
- **HFP-2462 Improve after review**
- **HFP-2451 Fix cover hidden state**
- **HFP-2451 Add comment to transitionend event listener**
- **HFP-2451 Rename link default title back to 'New link'**
- **HFP-2451 Remove showing URL for links without title**
- **HFP-2449 Add toggling of playing when switching chapters**
- **HFP-2451 Reduce duplicate code in statusbar.js**
- **HFP-2460 Focus interaction when navigating to it**
- **HFP-2451 Rename variables of statusbar**
- **HFP-2451 Add sass linting configuration file**
- **HFP-2451 Make sass linter happy**
- **HFP-2462 Use same xAPI 'completed' behavior as Column**
- **HFP-2472 Remove fullscreen button from cover**
- **HFP-2451 Fix classList.add/remove for IE11**
- **HFP-2451 Fix invalid scss rule**
- **HFP-2451 Fix hiding toggle menu button in footer status bar**
- **Fix styles not complying to default SASS rules**
- **HFP-2482 Allow user too mark a page as unfinished**
- **HFP-2451 Fix style for task indicator icon**
- **HFP-2450 Add lazy loading of pages**
- **HFP-2451 Fix section completion indicators**
- **HFP-2480 Change stylesheets**
- **Fix missing container to attach new instance to**
- **HFP-2480 Fix using color variable in scss file**
- **HFP-2448 Change navigation menu to not link to non-tasks**
- **Revert "Fix missing container to attach new instance to"**
- **HFP-2451 Make toggle menu button a button**
- **HFP-2451 Fix toTop button in bottom status bar**
- **HFP-2451 Fix statusbar buttons for prev/next**
- **HFP-2484 Add custom fullscreen behavior**
- **HFP-2482 Make status footer visible in fullscreen mode**
- **Add mode to webpack config**
- **HFP-2450 Fix page read marker notz showing for lazy loading**
- **HFP-2484 Adjust stylesheet**
- **HFP-2484 Fix fullscreen state change handling**
- **HFP-2484 Make footer always visible on fullscreen**
- **HFP-2484 Make page content centered if width too large**
- **HFP-2498 Open chapter on click on sidebar chapter item**
- **HFP-2498 Change section display within sidebar**
- **HFP-2505 Fix navigation within chapter**
- **HFP-2485 Add mobile view for sidemenu**
- **HFP-2484 Add pointer on hovering fullscreen button**
- **HFP-2484 Hide horizontal scrollbar on fullscreen transition**
- **HFP-2485 Fix detection of expandable sidemenu item**
- **JI-992 Fix cursor for disabled navigation button**
- **HFP-2485 Add workaround for Android to prevent font boosting**
- **JI-994 Fix putting p tags inside p tags**
- **JI-994 Fix redesign cover page**
- **HFP-2484 Fix fullscreen button tabbing**
- **HFP-2506 Fix use Column to determine tasks**
- **HFP-2482 Fix to-top button in fullscreen mode**
- **Remove unused code**
- **HFP-2498 Fix opening first chapter in sidebar menu**
- **HFP-2507 Fix incorrect use of querySelector() result**
- **HFP-2484 Fix DOM ids for chapters/sections starting with a number**
- **HFP-2485 Change sidemenu behavior for mobile view**
- **HFP-2484 Reduce computation on resize**
- **HFP-2484 Change stylesheet to prepare for animation**
- **HFP-2484 Remove unnecessary event listening**
- **HFP-2507 Fix targeting correct section element in sidebar**
- **HFP-2484 Fix chapter fragment on statusbar chapter change**
- **HFP-2484 Change chapter change animation**
- **HFP-2484 Make chapter node use full width of content area**
- **HFP-2484 Fix content not clickable**
- **HFP-2484 Fix removal of animation classes**
- **HFP-2484 Clean up code**
- **HFP-2484 Fix chapter scrollbar on fullscreen**
- **HFP-2487 Fix footer not showing on load**
- **HFP-2485 Fix navigation width on mobile**
- **HFP-2484 Fix resize crashing without content**
- **HFP-2515 Fix resizse on menu toggle + menu button state**
- **HFP-2515 Fix resize after transition**
- **HFP-2484 Fix scrolling to top in fullscreen mode**
- **JI-989 Fix navigation bar height in fullscreen mode**
- **Revert "JI-989 Fix navigation bar height in fullscreen mode"**
- **JI-989 Fix navigation menu stickyness in fullscreen mode**
- **HFP-2516 Hide footer in fullscreen mode**
- **HFP-2485 Fix status bar title on narrow screens**
- **Make scss linter happy for statusbar stylesheet**
- **HFP-2485 Use medie query to set "mobile" view**
- **Make linter for scss happy**
- **Update translation template file (.en.json)**
- **Rename to Interactive Book**
- **Mark correct owner**
- **Capitalize content type title**
- **HFP-2562 Fix sidebar sections when progress indicators are off**
- **HFP-2570 Fix detection of window height**
- **HFP-2460 Add more human-readable a11y text for page progress indicator**
- **HFP-2571 Hide exit fullscreen button due to conflicts**
- **HFP-2565 Fix size of CP in fullscreen mode**
- **HFP-2566 Refactor layout so that Edge can display it**
- **HFP-2560 Fix fullscreen icon in IE11**
- **Fix progress indicator in IE11**
- **HFP-2561 Fix container shift on IE11**
- **HFP-2583 Fix inconsistent styling**
- **HFP-2582 Fix always show footer navigation**
- **HFP-2586 Fix update section indicators since they are visible**
- **Add content type icon**
- **Update npm lock file**
- **Mark library as alpha**
- **Bump patch version**
- **Fix vulnerabilities in npm packages**
- **Added estonian translation**
- **Create it.json**
- **Create eu.json**
- **JI-1193 Update dependencies to latest Image Hotspots**
- **Create nn.json**
- **Update nn.json**
- **Create nb.json**
- **Recursive BUMP**
- **Bump column**
- **Add Sami languages (sma, sme & smj)**
- **npm update**
- **Sebastian Rettig <serettig@posteo.de> updated German translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **HFP-2860 Add support for code snippets in wysiwyg fields**
- **Gerardo Fallani <g.fallani@gmail.com> updated Italian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Create bg.json**
- **Added Bulgarian Translation**
- **Create ar.json**
- **Add Arabic Languge**
- **HFP-2601 Moved the fullscreen icon to the status bar**
- **HFP-2601 Updated fonts**
- **HFP-2601 Updated font family**
- **HFP-2598 Scroll to the top when navigating**
- **HFP-2598 Scroll when clicking in the menu on the left**
- **Create pr-br.json**
- **Fix invalid JSON**
- **Use correct language code for Brazilian Portuguese**
- **HFP-2595 Set half-circle on chapters with started tasks.**
- **HFP-2597 If empty pages are found they are removed from the config**
- **HFP-2596, HFP-2591 Added visual changes**
- **Updated the eslint rules from h5p/h5p-dev-tools**
- **HFP-2600 Adjust menu height when more than 20 pages in the book**
- **Vertical centering of icon**
- **Added styling to scrollbar**
- **Display an empty book when it contains of only empty pages**
- **Removed media queries + don't display menu by default on small surfaces**
- **Align items in the menu according to the screenshot in HFP-2587**
- **Added scrolling to Apple devices when in fullscreen mode**
- **Added comments for new functions**
- **HFP-2708 Added a summary page.**
- **HFP-2708 Set display of summary as default.**
- **HFP-2708 Removed solved TODO**
- **HFP-2708 Fixed spelling error.**
- **Bump to newest Column**
- **HFP-2708 Adjustments after UX review**
- **Update eu.json**
- **Add es translation**
- **Add es_mx translation**
- **Rename es_mx.json to es-mx.json**
- **JI-1690 Bump because of H5P.Image dependency change in Questionnaire**
- **HFP-2855 Change to use "page" instead of "chapter" in strings**
- **HFP-2934 Fix resize parent trigger only once after toggling all chapters**
- **HFP-2932 Fix overlap of fullscreen buttons in edge < v18**
- **HFP-3025 Fix invalid lookup of title through content instance**
- **HFP-3025 Add missing translations**
- **Update nn.json**
- **Fix translations compatible with semantics**
- **HFP-2855 Fix search & replace doing too much**
- **npm update**
- **Bump**
- **Mark me as beta**
- **Fix always left align drop down button text**
- **Fix green shade not WCAG compatible**
- **Fix update icons**
- **Fix button arrow icon position**
- **Fix progress circle stretched in iOS**
- **Bump patch version**
- **Remove unused dependency to ava**
- **Create km.json**
- **HFP-3067 Add footer to bottom of content when in fullscreen**
- **HFP-3068 Change to using more verbs and getAnswerGiven() for determining if a task is answered/marked**
- **HFP-3069 Add score progress circle to summary page**
- **HFP-3070 Change indicator for finished task from checkmark to filled circle**
- **Create nl.json**
- **HFP-3067 Add design adjustments**
- **HFP-3068 Fix instances where we receive an xAPI event before chapters are initialized**
- **Add missing es-mx translations**
- **Add missing es translations**
- **Improve English grammar for 'You have to interact'**
- **Fix typo**
- **NPM update**
- **Bump patch**
- **Fix typo**
- **JI-1809 Remove unused function**
- **JI-1809 Stop decrementing tasksLeft if task is not started**
- **JI-1809 Fix code style**
- **Bump patch**
- **Remove beta mark**
- **Fix semi fullscreen bugs**
- **JI-1824 Fix sending parent to Column for relation in xAPI**
- **JI-1824 Fix triggering xapi scored when user actually submits their answers**
- **JI-1825 Add fallback for using iframe window if we don't have access to top window (e.g. embed)**
- **JI-1825 Fix equality check when content id is casted to integer**
- **JI-1826 Fix instance content data being overwritten for each created Column**
- **Bump patch**
- **Update niode modules**
- **JI-1851 Set activity started**
- **Bump patch**
- **Update km.json**
- **Update et.json**
- **Create fi.json**
- **Create cs.json**
- **Create bs.json**
- **Update German translation**
- **Fix description of interaction progress in semantics**
- **Finnish translation 66 %**
- **Finnish translation 100 %**
- **Stop crashing on Safari@iPhone**
- **Delete invalid language file (bs.json)**
- **Bump**
- **JI-1902 Bump Column version**
- **Fix patch version**
- **Create ko.json**
- **Create sl.json**
- **Create el.json**
- **Update ko.json**
- **Create fr.json**
- **Update fr.json**
- **Update package-lock**
- **Create sv.json**
- **Added Catalan translation: ca.json**
- **Update eu.json**
- **Gerardo Fallani <g.fallani@gmail.com> updated Italian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Sebastian Rettig <serettig@posteo.de> updated German translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Victor Correia <victorelbiecorreia@gmail.com> updated Afrikaans translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Update NPMs**
- **Bump patch (preparing release)**
- **Sanitize language files**
- **Adding Galician (gl) translation**
- **German Valero <gvalero@unam.mx> updated Spanish translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **German Valero <gvalero@unam.mx> updated Spanish (Mexico) translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Bohumil Havel <bhavelbrno@seznam.cz> updated Czech translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Victor Correia <victorelbiecorreia@gmail.com> updated Afrikaans translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Diputació de Barcelona <sistemas@snackson.com> updated Catalan translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Eivind Hansen <eth@efaktor.no> updated Norwegian Bokmål translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Add files via upload**
- **Remove image reference inside Hub icon**
- **Update nl.json**
- **Bohumil Havel <bhavelbrno@seznam.cz> updated Czech translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **HFP-3225 Add support for getCurrentState function**
- **HFP-3225 Add support to show summary screen of previous state**
- **Mahdi SARMADI RAD <mahdisarmadirad@gmail.com> updated Persian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Kait Krull <kait.krull@ut.ee> updated Estonian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Mahdi SARMADI RAD <mahdisarmadirad@gmail.com> updated Persian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Update fa.json**
- **JI-2533 IB implement 'getContext()'**
- **JI-2533 Fix Interactive Book has wrong key in context object**
- **JI-2677 Fix return empty context when showing cover**
- **Bump**
- **Bump**
- **JI-2703 Fix sending empty object**
- **Revert "JI-2703 Fix sending empty object"**
- **Complete list of excluded files in .h5pignore**
- **JI-2760 Fix content not initialized before summary**
- **JI-2760 Fix summary is only created when displayed**
- **Create tr.json**
- **Fix merge**
- **Iñigo Zendegi Urzelai <izendegi@mondragon.edu> updated Basque translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Kait Krull <kait.krull@ut.ee> updated Estonian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **HFP-3423 Add aria-label to navigation buttons**
- **Bump**
- **HFP-3423 Fix remove title attribute for 'back to top' button**
- **JI-2863 Show/hide submit button based on scoring and extra report is active**
- **JI-2863 Refactor code - create common variable that can be used anywhere**
- **JI-2863 Fix submit button condition**
- **JI-2863 Fix backwards compatibility**
- **Bump patch**
- **Change title to Interactive Book**
- **HFP-3431 Fix left menu contrast issue**
- **HFP-3437 Add focus to the answers submitted text when submitting**
- **Patricia Moncorge <contact@d-booker.net> updated French translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Maria PG <galiana1@gmail.com> updated Catalan translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **joep jacobs <jcb.jacobs@gmail.com> updated Dutch translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **JI-2969 Fix IB submit and reporting issue - Activity time reset when clicked on Restart button - Hide submit button if user hasn't made any changes like IV**
- **Giorgi Kevlishvili <giorgi@sulakauri.ge> added Georgian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Kees Koopman <kkoopman@edusparx.nl> updated Dutch translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Delete ka.json**
- **Bump**
- **Stop storing computable values in state**
- **Fix summary screen showing as previous state**
- **Revert comment change**
- **Bump**
- **Matīss Sīlis <matiss.silis@gmail.com> updated Latvian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **JI-3123 Fix summary displaying chapters as not read (content resume)**
- **JI-2969 IB prevent user to submit result over and over - Compare two states to check the content is changed - Reset the previous state on submit the answer - Detect small changes in nested children content**
- **Recursive bump**
- **Update ko.json**
- **Bump**
- **Update NPM modules**
- **Anonymous <noreply@weblate.org> updated Telugu translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **JI-3302 Fix sublist items in navigation menu hidden on collapse**
- **Fix tab-order for "Navigate to top" button**
- **JI-3298 Add ul element to navigation list**
- **Anonymous <noreply@weblate.org> updated French translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Matīss Sīlis <matiss.silis@gmail.com> updated Latvian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Sushumna Rao <sushumnarao@gmail.com> updated Telugu translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Nurbyek Khuansh <lighternurbek@gmail.com> updated Mongolian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Pedro Wagner <wagner@wapbr.com.br> updated Portuguese (Brazil) translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Make translation safe**
- **Update node modules**
- **Update node modules**
- **Update node modules**
- **Bump**
- **JI-3414 Fix autoplay (#93)**
- **JI-3411 Add styling to status-menu button on focus**
- **Recursive bump H5P.Audio + Video**
- **Allow video on start screen**
- **Add option to select base color**
- **Stop using implied centered cover description**
- **Add more styling options to description**
- **Fix misleading German translation**
- **Fix undefined base color**
- **Fix missing empty color for progress circle**
- **Add CSS overrided for sub content types**
- **Prepare for JI-3411**
- **HFP-3505 Make nav menu buttons keyboard accessible**
- **Use CSS custom properties for custom colors**
- **Bump**
- **Fix empty visual**
- **JI-3566 Fix displaying submit button on resume**
- **HFP-3513 Bump**
- **Antonio Aneiros <antonio.aneiros@gmail.com> updated Spanish translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **German Valero <gvalero@unam.mx> updated Spanish (Mexico) (es-MX) (es-MX) translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Nurbyek Khuansh <lighternurbek@gmail.com> updated Mongolian translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Antonio Aneiros <antonio.aneiros@gmail.com> updated Galician translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **vo manh cuong <vomanhcuong1612@gmail.com> updated Vietnamese translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **Bohumil Havel <bhavelbrno@seznam.cz> updated Czech translation using Weblate @ Deutsche H5P-Übersetzungscommunity.**
- **JI-3673 Cleanup for packages and replaced deprecated packages (#104)**
- **JI-3543 Wrong usage of aria-label on navigation buttons**
- **HFP-3565 Fix undefined aria-controls**
- **HFP-3562 Fix hiding hidden menu**
- **Bump**
- **Update sl.json**
- **HFP-3562 Fix hiding menu initially**
- **Bump terser from 5.14.1 to 5.14.2**
- **Update el.json**
- **JI-3411 Use SCSS color variable instead of fixed hex color code (#100)**
- **Translations update from Translate H5P (#109)**
- **Bump**
- **HFP-3598 Improve a11y for hambuger menu**
- **Bump**
- **Bump loader-utils from 2.0.2 to 2.0.4 (#114)**
- **JI-4348 Fix IB content crash when exiting page is removed - Set default page value to first page**
- **JI-4348 add appropriate comment message**
- **Bump version**
- **JI-4348 Fix IB content crash when exiting page is removed**
- **Bump**
- **HFP-3635 Fix using aria-label instead of title for hamburger menu**
- **Bump**
- **Recursive bump**
- **Bump**
- **Bump json5 from 2.2.1 to 2.2.3 (#118)**
- **Translations update from Translate H5P (#110)**
- **Create uk.json (#116)**
- **HFP-3156 fix lineheight of the title**
- **Bump patch version**
- **JI-4511 Fix IB: Auto-scroll to content with resume**
- **JI-4511 Improve the condition**
- **Translations update from Translate H5P (#121)**
- **Bump**
- **JI-4778 Changed the default behavior for setting active chapter based on url when creating columns**
- **Bump webpack from 5.73.0 to 5.76.0 (#125)**
- **Nadav Kavalerchik <nadavkav@gmail.com> updated Hebrew translation using Weblate @ Deutsche H5P-Übersetzungscommunity. (#127)**
- **JI-4534 Change label and description for cover media field (#128)**
- **Bump patch version**
- **Fix race condition for resizing content when sidebar toggle (#129)**
- **Fix race condition for resizing content when sidebar toggle (#129)**
- **Update node modules + bump**
- **Bump word-wrap from 1.2.3 to 1.2.4 (#130)**
- **HFP-3768 Add option to enable/disable "Restart" button (#131)**
- **Update node modules**
- **bump patch version**
- **Translations update from Translate H5P (#132)**
- **Translations update from Translate H5P (#135)**
- **Bump**
- **JI-5444 Fix state considered empty when unanswered + enable start over**
- **BUMP**
- **JI-5501 Fix restart button no longer working on summary**
- **ji-5501 bump**
- **JI-5444: Make sure to check boolean**
- **JI-5444: also check active chapter to prevent 0 score**
- **JI-5501 Fix problems with reset and resume**
- **JI-5444: only check chapter**
- **bump patch**
- **JI-5501 fix setting urlFragments in getCurrentState**
- **JI-5501 Fix reset without autoprogress**
- **Remove some evil**
- **bump patch**
- **Update NPMs**
- **Bump**
- **Translations update from Translate H5P (#144)**
- **Remove untranslatable color code**
- **HFP-3857 Set and check URL as needed for resume (#146)**
- **HFP-3857 bump**
- **HFP-3913 Add extra resize**
- **HFP-3876 bump minor version to use h5p-column 1.17**
- **HFP-3941 Fix echo video on cover (#150)**
- **BUMP**
- **Update node modules**
- **Bump braces from 3.0.2 to 3.0.3 (#152)**
- **Bump column version in semantics + bump patch**
- **LB-104 WIP: Show submit button despite Row (#153)**
- **Bump patch version**
- **JI-6533 use Column 1.17 in semantics, bump minor (#156)**
- **JI-6555 prevent default scroll and lti scroll (#159)**
- **JI-6555 Prevent focus at all in lti**
