### PR TITLE
JI-6344 fix incorrect contentdata

### DIFF
--- a/src/scripts/pagecontent.js
+++ b/src/scripts/pagecontent.js
@@ -218,10 +218,7 @@ class PageContent extends H5P.EventDispatcher {
       const columnNode = document.createElement('div');
 
       const instanceContentData = {
-        ...contentData,
-        metadata: {
-          ...contentData.metadata,
-        },
+        parent: self,
         previousState: (previousState) ? previousState.chapters[i].state : {}
       };
       const newInstance = H5P.newRunnable(config.chapters[i], contentId, undefined, undefined, instanceContentData);


### PR DESCRIPTION
You can't copy or use the same contentData on children, then isRoot() will evalute to true for them as well + other evil stuff. Now using the same impl. as Column