### PR TITLE
JI-6581 fix focus jumping on init

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -484,7 +484,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         const container = this.pageContent.container;
         container.scrollBy(0, -container.scrollHeight);
       }
-      else if (H5PIntegration.context !== 'lti') { // Will be changed in JI-6581 to not use H5PIntegration 
+      else {
         this.statusBarHeader.wrapper.scrollIntoView(true);
       }
     });
@@ -995,7 +995,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
 
       this.hideAllElements(true);
 
-      this.on('coverRemoved', () => {
+      this.on('coverRemoved', event => {
         this.hideAllElements(false);
 
         // Ensure that URL is updated, so getCurrentState will resume without showing cover
@@ -1013,8 +1013,8 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         this.setActivityStarted();
 
         // Focus header progress bar when cover is removed
-        // Will be changed in JI-6581 to not use H5PIntegration 
-        if (H5PIntegration.context !== 'lti') {
+        // Will be changed in JI-6581 to not use H5PIntegration
+        if (event.data) {
           this.statusBarHeader.progressBar.progress.focus();
         }
       });

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -485,6 +485,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         container.scrollBy(0, -container.scrollHeight);
       }
       else {
+        console.log('should i scroll or nah?', event)
         if (event.data !== false) { // Note: undefined is treated as true here
           this.statusBarHeader.wrapper.scrollIntoView(true);
         }
@@ -1015,8 +1016,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
         // setActivityStarted() checks if it has been run before
         this.setActivityStarted();
 
-        // Focus header progress bar when cover is removed
-        // Will be changed in JI-6581 to not use H5PIntegration
+        // Focus header progress bar when cover is removed by user action
         if (event.data) {
           this.statusBarHeader.progressBar.progress.focus();
         }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -479,13 +479,15 @@ export default class InteractiveBook extends H5P.EventDispatcher {
       }
     });
 
-    this.on('scrollToTop', () => {
+    this.on('scrollToTop', event => {
       if (H5P.isFullscreen === true) {
         const container = this.pageContent.container;
         container.scrollBy(0, -container.scrollHeight);
       }
       else {
-        this.statusBarHeader.wrapper.scrollIntoView(true);
+        if (event.data !== false) { // Note: undefined is treated as true here
+          this.statusBarHeader.wrapper.scrollIntoView(true);
+        }
       }
     });
 
@@ -528,7 +530,7 @@ export default class InteractiveBook extends H5P.EventDispatcher {
       }
 
       H5P.trigger(this, 'changeHash', event.data);
-      H5P.trigger(this, 'scrollToTop');
+      H5P.trigger(this, 'scrollToTop', event.data.focus);
     });
 
     /**
@@ -1003,7 +1005,8 @@ export default class InteractiveBook extends H5P.EventDispatcher {
           this.trigger('newChapter', {
             h5pbookid: this.contentId,
             chapter: `h5p-interactive-book-chapter-${this.params.chapters[this.activeChapter].subContentId}`,
-            section: 0
+            section: 0,
+            focus: event.data
           });
         }
 

--- a/src/scripts/cover.js
+++ b/src/scripts/cover.js
@@ -215,7 +215,7 @@ class Cover extends H5P.EventDispatcher {
     const button = document.createElement('button');
     button.innerHTML = buttonText;
     button.onclick = () => {
-      this.removeCover();
+      this.removeCover(true);
     };
 
     const buttonWrapper = document.createElement('div');
@@ -228,14 +228,14 @@ class Cover extends H5P.EventDispatcher {
   /**
    * Remove cover.
    */
-  removeCover() {
+  removeCover(focus = false) {
     if (this.container.parentElement) {
       this.container.parentElement.classList.remove('covered');
       this.container.parentElement.removeChild(this.container);
     }
 
     this.hidden = true;
-    this.parent.trigger('coverRemoved');
+    this.parent.trigger('coverRemoved', focus);
   }
 }
 


### PR DESCRIPTION
We must avoid moving the focus when initializing the content. We can't rely on context for this.