### PR TITLE
VA-917 Increase line height for page title text

### DIFF
--- a/src/styles/_statusbar.scss
+++ b/src/styles/_statusbar.scss
@@ -164,6 +164,7 @@
           font-family: var(--h5p-theme-font-name);
           font-size: var(--h5p-theme-font-size-m);
           font-weight: 700;
+          line-height: 1.1;
           margin: 0;
           overflow: hidden;
           text-decoration: none solid $mud;


### PR DESCRIPTION
When merged in, will increase the line height of the page title text to not cut off "y" or "g" at the bottom.