### PR TITLE
fix: Fix HTML entities in status bar

### DIFF
--- a/src/scripts/statusbar.js
+++ b/src/scripts/statusbar.js
@@ -1,4 +1,20 @@
 /**
+ * Strips html tags and converts special characters.
+ * Example: "<div>Me &amp; you</div>" is converted to "Me & you".
+ *
+ * @param {String} text The text to be parsed
+ * @returns {String} The parsed text
+ */
+const parseString = (text) => {
+  if (text === null || text === undefined) {
+    return '';
+  }
+  const div = document.createElement('div');
+  div.innerHTML = text;
+  return div.textContent;
+};
+
+/**
  * Constructor function.
  */
 class StatusBar extends H5P.EventDispatcher {
@@ -54,7 +70,7 @@ class StatusBar extends H5P.EventDispatcher {
 
     if (params.title) {
       const title = document.createElement('h2');
-      title.textContent = params.title;
+      title.textContent = parseString(params.title);
       sidebarTitle.appendChild(title);
       new H5P.Tooltip(title, {
         text: params.title,


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
See https://h5p.org/node/1565659
The status bars in the navigation panel to the left receives a title string with HTML entities: Apostrophes will be rendered as &#039;, etc.

**What is the new behaviour?**
Cleaned the string by using the `parseString` function which is also used in H5P.Components. HTML entities will be displayed correctly.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
